### PR TITLE
Inference bug fix

### DIFF
--- a/inference/config_reader.py
+++ b/inference/config_reader.py
@@ -17,7 +17,7 @@ def config_reader():
     param['use_gpu'] = int(param['use_gpu'])
     param['starting_range'] = float(param['starting_range'])
     param['ending_range'] = float(param['ending_range'])
-    param['scale_search'] = map(float, param['scale_search'])
+    param['scale_search'] = list(map(float, param['scale_search']))
     param['thre1'] = float(param['thre1'])
     param['thre2'] = float(param['thre2'])
     param['thre3'] = float(param['thre3'])


### PR DESCRIPTION
There is bug with [process](https://github.com/kevinlin311tw/keras-openpose-reproduce/blob/master/inference/prediction.py#L32) function in predict.py, which makes this function usable only on first call.

The source of this problem comes from [config_reader.py](https://github.com/kevinlin311tw/keras-openpose-reproduce/blob/master/inference/config_reader.py#L20):
`param['scale_search'] = map(float, param['scale_search'])`

where `param['scale_search']` becomes usable only once in [process.py](https://github.com/kevinlin311tw/keras-openpose-reproduce/blob/master/inference/prediction.py#L35). next calls to process function will return unchanged image.

By changing
`param['scale_search'] = map(float, param['scale_search'])`
to
`param['scale_search'] = list(map(float, param['scale_search']))`

we can solve this problem